### PR TITLE
Improve GPU memory handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,19 @@ soundfile
 DeepCache
 ```
 
+## VRAM Management
+
+This extension includes a small helper script `memory_limiter.py` to control how
+much GPU memory the node can use. By default it adjusts the allowed fraction
+based on your GPU size (up to 95% for a 24GB card like the RTX 4090).
+
+```bash
+python memory_limiter.py  # Optional standalone usage
+```
+
+`LatentSyncNode` automatically calls `limit_gpu_memory()` so you typically don't
+need to run the script manually.
+
 ## Manual Model Download Required
 
 **Important**: LatentSync 1.6 requires manual model downloads because the LatentSync 1.6 models are hosted on a private HuggingFace repository that cannot be automatically accessed. You must download the following models before first use:

--- a/memory_limiter.py
+++ b/memory_limiter.py
@@ -1,0 +1,30 @@
+import torch
+import gc
+
+
+def limit_gpu_memory(memory_fraction=None):
+    """Limit GPU memory usage to a fraction of total VRAM."""
+    if torch.cuda.is_available():
+        if memory_fraction is None:
+            total_gb = torch.cuda.get_device_properties(0).total_memory / (1024 ** 3)
+            if total_gb >= 24:
+                memory_fraction = 0.95
+            elif total_gb >= 16:
+                memory_fraction = 0.9
+            else:
+                memory_fraction = 0.83
+        torch.cuda.set_per_process_memory_fraction(memory_fraction)
+        torch.cuda.empty_cache()
+        gc.collect()
+
+
+def clear_cache_periodically():
+    """Clear GPU cache to free memory."""
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+        torch.cuda.synchronize()
+    gc.collect()
+
+
+if __name__ == "__main__":
+    limit_gpu_memory()

--- a/nodes.py
+++ b/nodes.py
@@ -6,6 +6,8 @@ import sys
 import shutil
 from collections.abc import Mapping
 from datetime import datetime
+import gc
+from .memory_limiter import limit_gpu_memory
 
 # Function to find ComfyUI directories
 def get_comfyui_temp_dir():
@@ -500,9 +502,9 @@ class LatentSyncNode:
                 torch.backends.cuda.matmul.allow_tf32 = True
                 torch.backends.cudnn.allow_tf32 = True
 
-            # Clear GPU cache before processing
+            # Clear GPU cache before processing and set memory fraction
             torch.cuda.empty_cache()
-            torch.cuda.set_per_process_memory_fraction(0.8)
+            limit_gpu_memory()
 
         # Create a run-specific subdirectory in our temp directory
         run_id = ''.join(random.choice("abcdefghijklmnopqrstuvwxyz") for _ in range(5))
@@ -531,17 +533,17 @@ class LatentSyncNode:
             # Get the extension directory
             cur_dir = os.path.dirname(os.path.abspath(__file__))
             
-            # Process input frames
+            # Process input frames entirely on CPU to avoid unnecessary GPU
+            # memory usage before inference
             if isinstance(images, list):
-                frames = torch.stack(images).to(device)
+                frames_cpu = torch.stack(images).cpu()
             else:
-                frames = images.to(device)
- 
-            frames_cpu = frames.cpu()  
-            del frames  
-            torch.cuda.empty_cache()  
+                frames_cpu = images.cpu()
 
-            frames = (frames_cpu * 255).to(torch.uint8)
+            frames_uint8 = (frames_cpu * 255).to(torch.uint8)
+            del frames_cpu
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
 
             # Process audio with device awareness
             waveform = audio["waveform"].to(device)
@@ -567,27 +569,28 @@ class LatentSyncNode:
             # Move waveform to CPU for saving
             waveform_cpu = waveform.cpu()
             torchaudio.save(audio_path, waveform_cpu, sample_rate)
+            del waveform_cpu
+            gc.collect()
 
-            # Move frames to CPU for saving to video
-            frames_cpu = frames.cpu()
+            # Write video frames
             try:
                 import torchvision.io as io
-                io.write_video(temp_video_path, frames_cpu, fps=25, video_codec='h264')
+                io.write_video(temp_video_path, frames_uint8, fps=25, video_codec='h264')
             except TypeError as e:
                 # Check if the error is specifically about macro_block_size
                 if "macro_block_size" in str(e):
                     import imageio
                     # Use imageio with macro_block_size parameter
-                    imageio.mimsave(temp_video_path, frames_cpu.numpy(), fps=25, codec='h264', macro_block_size=1)
+                    imageio.mimsave(temp_video_path, frames_uint8.numpy(), fps=25, codec='h264', macro_block_size=1)
                 else:
                     # Fall back to original PyAV code for other TypeError issues
                     import av
                     container = av.open(temp_video_path, mode='w')
                     stream = container.add_stream('h264', rate=25)
-                    stream.width = frames_cpu.shape[2]
-                    stream.height = frames_cpu.shape[1]
+                    stream.width = frames_uint8.shape[2]
+                    stream.height = frames_uint8.shape[1]
 
-                    for frame in frames_cpu:
+                    for frame in frames_uint8:
                         frame = av.VideoFrame.from_ndarray(frame.numpy(), format='rgb24')
                         packet = stream.encode(frame)
                         container.mux(packet)
@@ -595,6 +598,9 @@ class LatentSyncNode:
                     packet = stream.encode(None)
                     container.mux(packet)
                     container.close()
+
+            del frames_uint8
+            gc.collect()
 
             # Define paths to required files and configs
             inference_script_path = os.path.join(cur_dir, "scripts", "inference.py")
@@ -668,8 +674,9 @@ class LatentSyncNode:
             inference_temp = os.path.join(temp_dir, "temp")
             os.makedirs(inference_temp, exist_ok=True)
             
-            # Run inference
-            inference_module.main(config, args)
+            # Run inference without gradient tracking to reduce memory usage
+            with torch.inference_mode():
+                inference_module.main(config, args)
 
             # Clean GPU cache after inference
             if torch.cuda.is_available():

--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -9,6 +9,7 @@ from latentsync.pipelines.lipsync_pipeline import LipsyncPipeline
 from accelerate.utils import set_seed
 from latentsync.whisper.audio2feature import Audio2Feature
 from DeepCache import DeepCacheSDHelper
+import gc
 
 
 def main(config, args):
@@ -153,6 +154,11 @@ def main(config, args):
         height=config.data.resolution,
         mask_image_path=config.data.mask_image_path,
     )
+
+    # Explicitly free models to release GPU memory
+    del pipeline, unet, vae, audio_encoder, helper, scheduler
+    torch.cuda.empty_cache()
+    gc.collect()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- create a memory limiter utility to dynamically set GPU memory fraction
- call limiter in `LatentSyncNode` before inference
- free pipeline models after inference to release VRAM
- document VRAM management in README

## Testing
- `python -m py_compile nodes.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6864c013ad808333926e1ea430448ee0